### PR TITLE
fix(security): prevent credential leak in npm package [BUG-729]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.env*
+node_modules/
+*.tgz
+test-e2e-prod/
+survi-next/
+survi-ssr/
+survicate-web-package/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Defense-in-depth: the "files" field in package.json is the primary guard.
+# This file is a secondary safeguard against accidental publishes of sensitive data.
+.env*
+.git/
+.github/
+test-*
+survi-*
+survicate-web-package/
+node_modules/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.7.1",
   "name": "@survicate/survicate-web-surveys-wrapper",
   "description": "Public Survicate web surveys wrapper",
   "author": {
@@ -15,5 +15,10 @@
     "url": "https://github.com/Survicate/survicate-web-surveys-wrapper/issues"
   },
   "main": "widget_wrapper.js",
-  "types": "types.d.ts"
+  "types": "widget_wrapper.d.ts",
+  "files": [
+    "widget_wrapper.js",
+    "widget_wrapper.d.ts",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## Summary

**SECURITY FIX — production credentials were publicly exposed in npm versions 1.6.0 and 1.7.0.**

- Adds `"files"` allowlist to `package.json` — only `widget_wrapper.js`, `widget_wrapper.d.ts`, and `README.md` are published
- Adds `.npmignore` as defense-in-depth
- Adds `.gitignore` to prevent committing sensitive local files
- Fixes `"types"` field to point to actual `widget_wrapper.d.ts` (was `types.d.ts`)
- Bumps version to 1.7.1

### Root cause

No `"files"` field, no `.npmignore`, no `.gitignore`. When `npm publish` was run manually from a working directory containing `test-e2e-prod/.env.production`, npm included everything — exposing production login credentials, 4 API keys, and 4 tracking codes for ~60 days.

### Verification

After this fix, `npm pack --dry-run` produces **4 files / 32KB** (was 67 files / 2.6MB).

## Required follow-up actions (outside this PR)

1. ⚠️ **Rotate password** for `marcin.cierpicki+e2e@survicate.com` (or disable account)
2. ⚠️ **Revoke + rotate** all 4 leaked production API keys
3. ⚠️ **Rotate** 4 tracking codes (if feasible without breaking live embeds)
4. `npm deprecate @survicate/survicate-web-surveys-wrapper@1.6.0 "Security: credentials leaked, upgrade to >=1.7.1"`
5. `npm deprecate @survicate/survicate-web-surveys-wrapper@1.7.0 "Security: credentials leaked, upgrade to >=1.7.1"`
6. Publish 1.7.1 to npm after merging this PR

## Test plan

- [x] `npm pack --dry-run` shows only 4 files (widget_wrapper.js, widget_wrapper.d.ts, README.md, package.json)
- [ ] Verify npm install of 1.7.1 works correctly in a consumer project
- [ ] Confirm deprecated versions show warning on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)