### PR TITLE
ci: add workflow_dispatch publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to publish from'
+        required: false
+        default: 'development'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Safety check
+        run: |
+          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
+          printf '%s\n' "$pack_output"
+          pack_files="$(printf '%s\n' "$pack_output" | grep '^npm notice ' | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' || true)"
+          if printf '%s\n' "$pack_files" | grep -qiE '\.env|credentials|secret|\.pem|\.key|\.npmrc|id_rsa|id_ed25519'; then
+            echo "::error::Sensitive files detected in npm package! Aborting."
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Actions workflow for publishing `@survicate/survicate-web-surveys-wrapper` to npmjs.org
- Replaces local `npm publish` to prevent credential leaks (BUG-729)
- Includes a safety check that scans `npm pack --dry-run` output for sensitive files (`.env`, credentials, keys, etc.) before publishing

## Test plan
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Trigger the workflow manually and confirm it publishes successfully
- [ ] Confirm the safety check blocks publishing if sensitive files are detected
- [ ] Verify `NPM_TOKEN` secret is configured in the repository settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)