### PR TITLE
ci: add release notes and safety fixes to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Short release description'
         required: true
 
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -26,8 +30,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Check version not already published
+      - name: Check version not already tagged
         run: |
+          set -o pipefail
           VERSION=$(jq -r .version package.json)
           if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
             echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
@@ -48,6 +53,12 @@ jobs:
             exit 1
           fi
 
+      - name: Create git tag
+        run: |
+          VERSION=$(jq -r .version package.json)
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
       - name: Publish
         run: npm publish --ignore-scripts
         env:
@@ -59,8 +70,6 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
           VERSION=$(jq -r .version package.json)
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
           notes_file="$(mktemp)"
           trap 'rm -f "$notes_file"' EXIT
           printf '%s' "$RELEASE_NOTES" > "$notes_file"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,14 +34,18 @@ jobs:
         run: |
           set -o pipefail
           VERSION=$(jq -r .version package.json)
-          if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
             exit 1
           fi
 
       - name: Safety check
         run: |
-          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
+          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)" || {
+            echo "::error::npm pack failed:"
+            printf '%s\n' "$pack_output"
+            exit 1
+          }
           printf '%s\n' "$pack_output"
           pack_files="$(printf '%s\n' "$pack_output" \
             | grep '^npm notice ' \
@@ -53,16 +57,16 @@ jobs:
             exit 1
           fi
 
+      - name: Publish
+        run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create git tag
         run: |
           VERSION=$(jq -r .version package.json)
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
-
-      - name: Publish
-        run: npm publish --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to publish from'
+        required: false
+        default: 'development'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Safety check
+        run: |
+          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
+          printf '%s\n' "$pack_output"
+          pack_files="$(printf '%s\n' "$pack_output" | grep '^npm notice ' | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' || true)"
+          if printf '%s\n' "$pack_files" | grep -qiE '\.env|credentials|secret|\.pem|\.key|\.npmrc|id_rsa|id_ed25519'; then
+            echo "::error::Sensitive files detected in npm package! Aborting."
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,15 @@ on:
         description: 'Branch or tag to publish from'
         required: false
         default: 'development'
+      release_notes:
+        description: 'Short release description'
+        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -25,13 +30,28 @@ jobs:
         run: |
           pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
           printf '%s\n' "$pack_output"
-          pack_files="$(printf '%s\n' "$pack_output" | grep '^npm notice ' | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' || true)"
-          if printf '%s\n' "$pack_files" | grep -qiE '\.env|credentials|secret|\.pem|\.key|\.npmrc|id_rsa|id_ed25519'; then
+          pack_files="$(printf '%s\n' "$pack_output" \
+            | grep '^npm notice ' \
+            | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' \
+            | sed -E 's/^npm notice[[:space:]]+([0-9.]+[kKMGT]?B[[:space:]]+)?//' \
+            || true)"
+          if printf '%s\n' "$pack_files" | grep -qiE '(^|/)\.env(\.[^/]+)?$|(^|/)\.npmrc$|(^|/)(id_rsa|id_ed25519)$|(^|/)[^/]+\.(pem|key)$|(^|/)(credentials|secret|secrets)(\.(json|ya?ml|env|txt))?$'; then
             echo "::error::Sensitive files detected in npm package! Aborting."
             exit 1
           fi
 
       - name: Publish
-        run: npm publish
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "${{ github.event.inputs.release_notes }}"


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` publish workflow — never publish from local machine again
- Safety check: scans `npm pack` output for sensitive files before publishing
- Creates git tag + GitHub release with user-provided release notes after publish
- Uses `--ignore-scripts` on publish to prevent running scripts with auth token in env

## How to use
1. Go to Actions → "Publish to NPM" → Run workflow
2. Pick branch, write a short release description
3. Run — publishes to npm and creates a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)